### PR TITLE
ボタン制御の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 local.properties
 .idea/
 app/google-services.json
+app/release/

--- a/app/src/main/java/biz/moapp/transcription_app/ui/compose/EditField.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/compose/EditField.kt
@@ -1,0 +1,32 @@
+package biz.moapp.transcription_app.ui.compose
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import biz.moapp.transcription_app.ui.main.MainScreenViewModel
+
+@Composable
+fun EditField(mainScreenViewModel: MainScreenViewModel,enabled :Boolean){
+
+    var text by remember { mutableStateOf(mainScreenViewModel.summaryText.value) }
+    val systemColor = if (isSystemInDarkTheme()) Color.White else Color.Black
+    BasicTextField(
+        value = text,
+        enabled = enabled,
+        onValueChange = {
+            text = it
+            mainScreenViewModel.setSummaryText(it) },
+        modifier = Modifier.fillMaxSize().padding(8.dp),
+        textStyle = TextStyle(color = systemColor)
+    )
+}

--- a/app/src/main/java/biz/moapp/transcription_app/ui/compose/OperationButton.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/compose/OperationButton.kt
@@ -11,10 +11,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun OperationButton(modifier: Modifier, buttonName : String, clickAction:() -> Unit){
+fun OperationButton(modifier: Modifier, enabled: Boolean = true, buttonName : String, clickAction:() -> Unit){
     Button(modifier = modifier
         .padding(16.dp),
         shape = RoundedCornerShape(8.dp),
+        enabled = enabled,
         border = BorderStroke(1.dp, Color.Black),
         onClick = {clickAction()}){
         Text(modifier = Modifier.padding(8.dp), text = buttonName)

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -64,6 +64,11 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             targetState = true
         }
     }
+    val summaryAreaState = remember {
+        MutableTransitionState(false).apply {
+            targetState = true
+        }
+    }
     val context = LocalContext.current
     val recorder = remember { MediaRecorder(context) }
     val filePath : String = context.getExternalFilesDir(null)?.absolutePath + "/recording.m4a"
@@ -97,55 +102,63 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             }
             is MainUiState.SendResultState.Success -> {
                 (mainScreenViewModel.uiState.sendResultState as MainUiState.SendResultState.Success).results.map { value ->
-                    Log.d("--result response：　",value)
-                    OutlinedCard(
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surface,
-                        ),
-                        border = BorderStroke(1.dp, systemColor),
-                        modifier = Modifier
-                            .fillMaxSize(),
-                    ) {
-                        Text(
-                            text = "要約した内容",
-                            color = systemColor,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.padding(4.dp)
-                        )
-                        Text(text = mainScreenViewModel.summaryText.value, color = systemColor,
-                            style = TextStyle.Default.copy(lineBreak = LineBreak.Paragraph),
-                            modifier = Modifier.padding(4.dp)
-                        )
-                    }
-                    Row(modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center
-                    ){
-
-                        /**編集ボタン**/
-                        OperationButton(
-                            modifier = Modifier.weight(0.5f),
-                            buttonName = "Edit Text",
-                            clickAction = {
-                                onNavigateToEdit()
+                    Log.d("--result response：　", value)
+                    AnimatedVisibility(visibleState = summaryAreaState) {
+                        Column {
+                            OutlinedCard(
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.surface,
+                                ),
+                                border = BorderStroke(1.dp, systemColor),
+                                modifier = Modifier
+                                    .fillMaxSize(),
+                            ) {
+                                Text(
+                                    text = "要約した内容",
+                                    color = systemColor,
+                                    fontWeight = FontWeight.Bold,
+                                    modifier = Modifier.padding(4.dp)
+                                )
+                                Text(
+                                    text = mainScreenViewModel.summaryText.value,
+                                    color = systemColor,
+                                    style = TextStyle.Default.copy(lineBreak = LineBreak.Paragraph),
+                                    modifier = Modifier.padding(4.dp)
+                                )
                             }
-                        )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.Center
+                            ) {
 
-                        /**リセットボタン**/
-                        OperationButton(
-                            modifier = Modifier.weight(0.5f),
-                            buttonName = "Reset",
-                            clickAction = {
+                                /**編集ボタン**/
+                                OperationButton(
+                                    modifier = Modifier.weight(0.5f),
+                                    buttonName = "Edit Text",
+                                    clickAction = {
+                                        onNavigateToEdit()
+                                    }
+                                )
 
+                                /**リセットボタン**/
+                                OperationButton(
+                                    modifier = Modifier.weight(0.5f),
+                                    buttonName = "Reset",
+                                    clickAction = {
+                                        isAudioButtonVisible = true
+                                        /**要約エリア表示**/
+                                        summaryAreaState.targetState = !summaryAreaState.currentState
+                                    }
+                                )
                             }
-                        )
-
+                            /**要約した内容の保存**/
+                            OperationButton(
+                                modifier = maxModifierButton,
+                                buttonName = "save",
+                                clickAction = { mainScreenViewModel.summarySave(value) }
+                            )
+                        }
                     }
-                    /**要約した内容の保存**/
-                    OperationButton(
-                        modifier = maxModifierButton,
-                        buttonName = "save",
-                        clickAction = { mainScreenViewModel.summarySave(value) }
-                    )
                 }
             }
             is MainUiState.SendResultState.Error -> {}
@@ -192,6 +205,8 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                                 mainScreenViewModel.summary(mainScreenViewModel.audioText.value)
                                 /**要約ボタン非表示**/
                                 convertTextAreaState.targetState = !convertTextAreaState.currentState
+                                /**要約エリア表示**/
+                                summaryAreaState.targetState = !summaryAreaState.currentState
                             }
                         )
                     }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -59,7 +59,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             targetState = false
         }
     }
-    val summaryButtonState = remember {
+    val convertTextAreaState = remember {
         MutableTransitionState(false).apply {
             targetState = true
         }
@@ -156,7 +156,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             is UIState.NotYet -> {}
             is UIState.Loading -> {CircularProgressIndicator()}
             is UIState.Success -> {
-                AnimatedVisibility(visibleState = summaryButtonState) {
+                AnimatedVisibility(visibleState = convertTextAreaState) {
                 Spacer(modifier = Modifier.height(5.dp))
                     Column {
                         OutlinedCard(
@@ -191,7 +191,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                             clickAction = {
                                 mainScreenViewModel.summary(mainScreenViewModel.audioText.value)
                                 /**要約ボタン非表示**/
-                                summaryButtonState.targetState = !summaryButtonState.currentState
+                                convertTextAreaState.targetState = !convertTextAreaState.currentState
                             }
                         )
                     }
@@ -214,7 +214,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                     /**テキスト変換ボタン非表示**/
                     convertTextButtonState.targetState = !convertTextButtonState.currentState
                     /**要約ボタン表示**/
-                    summaryButtonState.targetState = !summaryButtonState.currentState
+                    convertTextAreaState.targetState = !convertTextAreaState.currentState
                 }
             )
         }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -53,6 +53,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var isPlaying by remember { mutableStateOf(false) }
     var isAudioButtonVisible by remember { mutableStateOf(true) }
     var isConvertButtonVisible by remember { mutableStateOf(false) }
+    var isAudioPlayButtonVisible by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val recorder = remember { MediaRecorder(context) }
     val filePath : String = context.getExternalFilesDir(null)?.absolutePath + "/recording.m4a"
@@ -179,6 +180,8 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             clickAction = { mainScreenViewModel.openAiAudioApi(filePath)
                 /**レコーディング操作ボタン非表示**/
                 isAudioButtonVisible = false
+                /**オーディオ操作ボタン非表示**/
+                isAudioPlayButtonVisible = false
             }
         )
 
@@ -198,6 +201,9 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                         }else{
                             /**Convert Textボタン表示**/
                             isConvertButtonVisible = true
+                            /**オーディオ操作ボタン表示**/
+                            isAudioPlayButtonVisible = true
+                            /**レコーディング停止**/
                             mainScreenViewModel.recordingStop(recorder)
                         }
                     })
@@ -206,7 +212,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                 OperationButton(
                     modifier = Modifier.weight(0.5f),
                     buttonName = if (!isPlaying) "Audio Play" else "Audio Stop",
-                    enabled = isAudioButtonVisible,
+                    enabled = isAudioPlayButtonVisible,
                     clickAction = {
                         mainScreenViewModel.audioPlay(filePath)
                     }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.unit.dp
+import biz.moapp.transcription_app.ui.compose.EditField
 import biz.moapp.transcription_app.ui.state.MainUiState
 import biz.moapp.transcription_app.ui.state.UIState
 import biz.moapp.transcription_app.ui.compose.OperationButton
@@ -54,6 +55,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var isPlaying by remember { mutableStateOf(false) }
     var isAudioButtonVisible by remember { mutableStateOf(true) }
     var isAudioPlayButtonVisible by remember { mutableStateOf(false) }
+    var isEditable by remember { mutableStateOf(false) }
     val convertTextButtonState = remember {
         MutableTransitionState(true).apply {
             targetState = false
@@ -119,12 +121,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                                     fontWeight = FontWeight.Bold,
                                     modifier = Modifier.padding(4.dp)
                                 )
-                                Text(
-                                    text = mainScreenViewModel.summaryText.value,
-                                    color = systemColor,
-                                    style = TextStyle.Default.copy(lineBreak = LineBreak.Paragraph),
-                                    modifier = Modifier.padding(4.dp)
-                                )
+                                EditField(mainScreenViewModel,isEditable)
                             }
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
@@ -134,9 +131,9 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                                 /**編集ボタン**/
                                 OperationButton(
                                     modifier = Modifier.weight(0.5f),
-                                    buttonName = "Edit Text",
+                                    buttonName = if(!isEditable) "Edit Text" else "Change Text",
                                     clickAction = {
-                                        onNavigateToEdit()
+                                        isEditable = !isEditable
                                     }
                                 )
 

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -114,13 +114,6 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                         horizontalArrangement = Arrangement.Center
                     ){
 
-                        /**要約した内容の保存**/
-                        OperationButton(
-                            modifier = Modifier.weight(0.5f),
-                            buttonName = "save",
-                            clickAction = { mainScreenViewModel.summarySave(value) }
-                        )
-
                         /**編集ボタン**/
                         OperationButton(
                             modifier = Modifier.weight(0.5f),
@@ -130,7 +123,22 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                             }
                         )
 
+                        /**リセットボタン**/
+                        OperationButton(
+                            modifier = Modifier.weight(0.5f),
+                            buttonName = "Reset",
+                            clickAction = {
+
+                            }
+                        )
+
                     }
+                    /**要約した内容の保存**/
+                    OperationButton(
+                        modifier = maxModifierButton,
+                        buttonName = "save",
+                        clickAction = { mainScreenViewModel.summarySave(value) }
+                    )
                 }
             }
             is MainUiState.SendResultState.Error -> {}

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -52,6 +52,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var isRecording by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(false) }
     var isAudioButtonVisible by remember { mutableStateOf(true) }
+    var isConvertButtonVisible by remember { mutableStateOf(false) }
     val context = LocalContext.current
     val recorder = remember { MediaRecorder(context) }
     val filePath : String = context.getExternalFilesDir(null)?.absolutePath + "/recording.m4a"
@@ -174,15 +175,18 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
         OperationButton(
             modifier = maxModifierButton,
             buttonName = "Convert Text",
+            enabled = isConvertButtonVisible,
             clickAction = { mainScreenViewModel.openAiAudioApi(filePath)
-                isAudioButtonVisible = false}
+                /**レコーディング操作ボタン非表示**/
+                isAudioButtonVisible = false
+            }
         )
 
         AnimatedVisibility(isAudioButtonVisible) {
             Row(modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center
             ){
-                /**レコード操作ボタン**/
+                /**レコーディング操作ボタン**/
                 OperationButton(
                     modifier = Modifier.weight(0.5f),
                     buttonName = if (!isRecording) "Recording Start" else " Recording Stop",
@@ -192,6 +196,8 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                         if (isRecording) {
                             mainScreenViewModel.recordingStart(recorder,filePath)
                         }else{
+                            /**Convert Textボタン表示**/
+                            isConvertButtonVisible = true
                             mainScreenViewModel.recordingStop(recorder)
                         }
                     })

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -146,7 +146,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                                     buttonName = "Reset",
                                     clickAction = {
                                         isAudioButtonVisible = true
-                                        /**要約エリア表示**/
+                                        /**要約エリア非表示**/
                                         summaryAreaState.targetState = !summaryAreaState.currentState
                                     }
                                 )
@@ -203,7 +203,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                             buttonName = "Summary Text",
                             clickAction = {
                                 mainScreenViewModel.summary(mainScreenViewModel.audioText.value)
-                                /**要約ボタン非表示**/
+                                /**文字起こしエリア非表示**/
                                 convertTextAreaState.targetState = !convertTextAreaState.currentState
                                 /**要約エリア表示**/
                                 summaryAreaState.targetState = !summaryAreaState.currentState
@@ -228,7 +228,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                     isAudioPlayButtonVisible = false
                     /**テキスト変換ボタン非表示**/
                     convertTextButtonState.targetState = !convertTextButtonState.currentState
-                    /**要約ボタン表示**/
+                    /**文字起こしエリア表示**/
                     convertTextAreaState.targetState = !convertTextAreaState.currentState
                 }
             )

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -246,10 +246,12 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                     clickAction = {
                         isRecording = !isRecording
                         if (isRecording) {
+                            /**Convert Textボタン非表示**/
+                            convertTextButtonState.targetState = false
                             mainScreenViewModel.recordingStart(recorder,filePath)
                         }else{
                             /**Convert Textボタン表示**/
-                            convertTextButtonState.targetState = !convertTextButtonState.currentState
+                            convertTextButtonState.targetState = true
                             /**オーディオ操作ボタン表示**/
                             isAudioPlayButtonVisible = true
                             /**レコーディング停止**/

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -54,6 +54,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var isAudioButtonVisible by remember { mutableStateOf(true) }
     var isConvertButtonVisible by remember { mutableStateOf(false) }
     var isAudioPlayButtonVisible by remember { mutableStateOf(false) }
+    var isSummaryButtonVisible by remember { mutableStateOf(true) }
     val context = LocalContext.current
     val recorder = remember { MediaRecorder(context) }
     val filePath : String = context.getExternalFilesDir(null)?.absolutePath + "/recording.m4a"
@@ -86,6 +87,8 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                 CircularProgressIndicator()
             }
             is MainUiState.SendResultState.Success -> {
+                /**要約ボタン非表示**/
+                isSummaryButtonVisible = false
                 (mainScreenViewModel.uiState.sendResultState as MainUiState.SendResultState.Success).results.map { value ->
                     Log.d("--result response：　",value)
                     OutlinedCard(
@@ -162,15 +165,17 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                         style = TextStyle.Default.copy(lineBreak = LineBreak.Paragraph),
                         modifier = Modifier.padding(4.dp))
                 }
-
-                    /**要約ボタン**/
-                    OperationButton(
-                        modifier = maxModifierButton,
-                        buttonName = "Summary Text",
-                        clickAction = {
-                            mainScreenViewModel.summary(mainScreenViewModel.audioText.value)
-                        }
-                    )
+                    AnimatedVisibility(isSummaryButtonVisible) {
+                        /**要約ボタン**/
+                        OperationButton(
+                            modifier = maxModifierButton,
+                            buttonName = "Summary Text",
+                            enabled = isSummaryButtonVisible,
+                            clickAction = {
+                                mainScreenViewModel.summary(mainScreenViewModel.audioText.value)
+                            }
+                        )
+                    }
             }
             is UIState.Error -> {Text(text = "Error: ${(mainUiState as UIState.Error).message}")}
         }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -52,9 +53,13 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var isRecording by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(false) }
     var isAudioButtonVisible by remember { mutableStateOf(true) }
-    var isConvertButtonVisible by remember { mutableStateOf(false) }
     var isAudioPlayButtonVisible by remember { mutableStateOf(false) }
     var isSummaryButtonVisible by remember { mutableStateOf(true) }
+    val convertTextButtonState = remember {
+        MutableTransitionState(true).apply {
+            targetState = false
+        }
+    }
     val context = LocalContext.current
     val recorder = remember { MediaRecorder(context) }
     val filePath : String = context.getExternalFilesDir(null)?.absolutePath + "/recording.m4a"
@@ -149,8 +154,6 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             is UIState.NotYet -> {}
             is UIState.Loading -> {CircularProgressIndicator()}
             is UIState.Success -> {
-                /**テキスト変換ボタン非表示**/
-                isConvertButtonVisible = false
 
                 Spacer(modifier = Modifier.height(5.dp))
                 OutlinedCard(
@@ -189,17 +192,18 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
         }
 
         /**テキスト変換ボタン**/
-        AnimatedVisibility(isConvertButtonVisible) {
+        AnimatedVisibility(visibleState = convertTextButtonState) {
             OperationButton(
                 modifier = maxModifierButton,
                 buttonName = "Convert Text",
-                enabled = isConvertButtonVisible,
                 clickAction = {
                     mainScreenViewModel.openAiAudioApi(filePath)
                     /**レコーディング操作ボタン非表示**/
                     isAudioButtonVisible = false
                     /**オーディオ操作ボタン非表示**/
                     isAudioPlayButtonVisible = false
+                    /**テキスト変換ボタン非表示**/
+                    convertTextButtonState.targetState = !convertTextButtonState.currentState
                 }
             )
         }
@@ -219,7 +223,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                             mainScreenViewModel.recordingStart(recorder,filePath)
                         }else{
                             /**Convert Textボタン表示**/
-                            isConvertButtonVisible = true
+                            convertTextButtonState.targetState = !convertTextButtonState.currentState
                             /**オーディオ操作ボタン表示**/
                             isAudioPlayButtonVisible = true
                             /**レコーディング停止**/

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -138,6 +138,9 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             is UIState.NotYet -> {}
             is UIState.Loading -> {CircularProgressIndicator()}
             is UIState.Success -> {
+                /**テキスト変換ボタン非表示**/
+                isConvertButtonVisible = false
+
                 Spacer(modifier = Modifier.height(5.dp))
                 OutlinedCard(
                     colors = CardDefaults.cardColors(
@@ -173,17 +176,20 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
         }
 
         /**テキスト変換ボタン**/
-        OperationButton(
-            modifier = maxModifierButton,
-            buttonName = "Convert Text",
-            enabled = isConvertButtonVisible,
-            clickAction = { mainScreenViewModel.openAiAudioApi(filePath)
-                /**レコーディング操作ボタン非表示**/
-                isAudioButtonVisible = false
-                /**オーディオ操作ボタン非表示**/
-                isAudioPlayButtonVisible = false
-            }
-        )
+        AnimatedVisibility(isConvertButtonVisible) {
+            OperationButton(
+                modifier = maxModifierButton,
+                buttonName = "Convert Text",
+                enabled = isConvertButtonVisible,
+                clickAction = {
+                    mainScreenViewModel.openAiAudioApi(filePath)
+                    /**レコーディング操作ボタン非表示**/
+                    isAudioButtonVisible = false
+                    /**オーディオ操作ボタン非表示**/
+                    isAudioPlayButtonVisible = false
+                }
+            )
+        }
 
         AnimatedVisibility(isAudioButtonVisible) {
             Row(modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -263,7 +263,12 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                     buttonName = if (!isPlaying) "Audio Play" else "Audio Stop",
                     enabled = isAudioPlayButtonVisible,
                     clickAction = {
-                        mainScreenViewModel.audioPlay(filePath)
+                        isPlaying = !isPlaying
+                        if(isPlaying){
+                            mainScreenViewModel.audioPlay(filePath)
+                        }else{
+                            mainScreenViewModel.audioStop()
+                        }
                     }
                 )
             }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -54,10 +54,14 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var isPlaying by remember { mutableStateOf(false) }
     var isAudioButtonVisible by remember { mutableStateOf(true) }
     var isAudioPlayButtonVisible by remember { mutableStateOf(false) }
-    var isSummaryButtonVisible by remember { mutableStateOf(true) }
     val convertTextButtonState = remember {
         MutableTransitionState(true).apply {
             targetState = false
+        }
+    }
+    val summaryButtonState = remember {
+        MutableTransitionState(false).apply {
+            targetState = true
         }
     }
     val context = LocalContext.current
@@ -92,8 +96,6 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                 CircularProgressIndicator()
             }
             is MainUiState.SendResultState.Success -> {
-                /**要約ボタン非表示**/
-                isSummaryButtonVisible = false
                 (mainScreenViewModel.uiState.sendResultState as MainUiState.SendResultState.Success).results.map { value ->
                     Log.d("--result response：　",value)
                     OutlinedCard(
@@ -154,39 +156,46 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
             is UIState.NotYet -> {}
             is UIState.Loading -> {CircularProgressIndicator()}
             is UIState.Success -> {
-
+                AnimatedVisibility(visibleState = summaryButtonState) {
                 Spacer(modifier = Modifier.height(5.dp))
-                OutlinedCard(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surface,
-                    ),
-                    border = BorderStroke(1.dp, systemColor),
-                    modifier = Modifier
-                            .fillMaxSize(),
-                ) {
-                    Text(text = "録音した内容",
-                        color = systemColor,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(4.dp))
+                    Column {
+                        OutlinedCard(
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                            ),
+                            border = BorderStroke(1.dp, systemColor),
+                            modifier = Modifier
+                                .fillMaxSize(),
+                        ) {
 
-                    Spacer(modifier = Modifier.height(1.dp))
+                            Text(
+                                text = "録音した内容",
+                                color = systemColor,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(4.dp)
+                            )
 
-                    Text(text = mainScreenViewModel.audioText.value,
-                        color = systemColor,
-                        style = TextStyle.Default.copy(lineBreak = LineBreak.Paragraph),
-                        modifier = Modifier.padding(4.dp))
-                }
-                    AnimatedVisibility(isSummaryButtonVisible) {
+                            Spacer(modifier = Modifier.height(1.dp))
+
+                            Text(
+                                text = mainScreenViewModel.audioText.value,
+                                color = systemColor,
+                                style = TextStyle.Default.copy(lineBreak = LineBreak.Paragraph),
+                                modifier = Modifier.padding(4.dp)
+                            )
+                        }
                         /**要約ボタン**/
                         OperationButton(
                             modifier = maxModifierButton,
                             buttonName = "Summary Text",
-                            enabled = isSummaryButtonVisible,
                             clickAction = {
                                 mainScreenViewModel.summary(mainScreenViewModel.audioText.value)
+                                /**要約ボタン非表示**/
+                                summaryButtonState.targetState = !summaryButtonState.currentState
                             }
                         )
                     }
+                }
             }
             is UIState.Error -> {Text(text = "Error: ${(mainUiState as UIState.Error).message}")}
         }
@@ -204,6 +213,8 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
                     isAudioPlayButtonVisible = false
                     /**テキスト変換ボタン非表示**/
                     convertTextButtonState.targetState = !convertTextButtonState.currentState
+                    /**要約ボタン表示**/
+                    summaryButtonState.targetState = !summaryButtonState.currentState
                 }
             )
         }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -84,11 +84,6 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
         .height(80.dp)
 
     /**UI**/
-    Column(modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Top) {
-        Text(text = speechStatus.value, color = Color.Magenta)
-    }
-
     Column(modifier = modifier
         .fillMaxSize()
         .verticalScroll(rememberScrollState()),

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -6,6 +6,7 @@ import android.media.MediaRecorder
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -50,6 +51,7 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
     var speechStatus = remember { mutableStateOf("No Speech") }
     var isRecording by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(false) }
+    var isAudioButtonVisible by remember { mutableStateOf(true) }
     val context = LocalContext.current
     val recorder = remember { MediaRecorder(context) }
     val filePath : String = context.getExternalFilesDir(null)?.absolutePath + "/recording.m4a"
@@ -172,33 +174,38 @@ fun MainScreen(modifier : Modifier, mainScreenViewModel: MainScreenViewModel,onN
         OperationButton(
             modifier = maxModifierButton,
             buttonName = "Convert Text",
-            clickAction = { mainScreenViewModel.openAiAudioApi(filePath) }
+            clickAction = { mainScreenViewModel.openAiAudioApi(filePath)
+                isAudioButtonVisible = false}
         )
 
-        Row(modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center
-        ){
-            /**レコード操作ボタン**/
-            OperationButton(
-                modifier = Modifier.weight(0.5f),
-                buttonName = if (!isRecording) "Recording Start" else " Recording Stop",
-                clickAction = {
-                    isRecording = !isRecording
-                    if (isRecording) {
-                        mainScreenViewModel.recordingStart(recorder,filePath)
-                    }else{
-                        mainScreenViewModel.recordingStop(recorder)
-                    }
-                })
+        AnimatedVisibility(isAudioButtonVisible) {
+            Row(modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ){
+                /**レコード操作ボタン**/
+                OperationButton(
+                    modifier = Modifier.weight(0.5f),
+                    buttonName = if (!isRecording) "Recording Start" else " Recording Stop",
+                    enabled = isAudioButtonVisible,
+                    clickAction = {
+                        isRecording = !isRecording
+                        if (isRecording) {
+                            mainScreenViewModel.recordingStart(recorder,filePath)
+                        }else{
+                            mainScreenViewModel.recordingStop(recorder)
+                        }
+                    })
 
-            /**オーディオ操作ボタン**/
-            OperationButton(
-                modifier = Modifier.weight(0.5f),
-                buttonName = if (!isPlaying) "Audio Play" else "Audio Stop",
-                clickAction = {
-                    mainScreenViewModel.audioPlay(filePath)
-                }
-            )
+                /**オーディオ操作ボタン**/
+                OperationButton(
+                    modifier = Modifier.weight(0.5f),
+                    buttonName = if (!isPlaying) "Audio Play" else "Audio Stop",
+                    enabled = isAudioButtonVisible,
+                    clickAction = {
+                        mainScreenViewModel.audioPlay(filePath)
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/summaryedit/SummaryEditScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/summaryedit/SummaryEditScreen.kt
@@ -67,7 +67,7 @@ fun SummaryEditScreen(mainScreenViewModel: MainScreenViewModel, onNavigateToMain
                     textStyle = TextStyle(color = systemColor)
                 )
             }
-            OperationButton(Modifier.fillMaxWidth(),"save") { onNavigateToMain() }
+            OperationButton(modifier = Modifier.fillMaxWidth(),buttonName = "save",) { onNavigateToMain() }
         }
 
     }


### PR DESCRIPTION
以下ボタンとエリアの制御を実装
- 要約エリア
- 録音後のテキストを表示するエリア
- テキストに変換するボタン(Convert Text)
- オーディオ再生ボタン(Audio Play, Audio Stop)
- レコーディング操作ボタン(Recording Stop, Record Stop)
- 要約後の表示テキストはMain画面で編集可能