### PR TITLE
 0807レビュー指摘取り込み（レコーディングボタンの配置箇所の修正）

### DIFF
--- a/app/src/main/java/biz/moapp/transcription_app/ui/compose/OperationButton.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/compose/OperationButton.kt
@@ -34,6 +34,6 @@ fun OperationButton(modifier: Modifier, enabled: Boolean = true, buttonName : St
         icon?.let{
             Icon(imageVector = it,contentDescription = "")
         }
-        Text(modifier = Modifier.padding(6.dp), text = buttonName)
+        Text(text = buttonName)
     }
 }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/compose/OperationButton.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/compose/OperationButton.kt
@@ -21,7 +21,7 @@ fun OperationButton(modifier: Modifier, enabled: Boolean = true, buttonName : St
     var shadowButton = remember { mutableIntStateOf(6) }
     Button(modifier = modifier
         .padding(16.dp),
-        shape = RoundedCornerShape(8.dp),
+        shape = RoundedCornerShape(40.dp),
         enabled = enabled,
         elevation =  ButtonDefaults.buttonElevation(defaultElevation = shadowButton.intValue.dp,),
         onClick = {

--- a/app/src/main/java/biz/moapp/transcription_app/ui/compose/RecordingButton.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/compose/RecordingButton.kt
@@ -31,11 +31,11 @@ fun RecordingButton(isEnable: Boolean,
             onToggle(!isEnable)
         },
         modifier = Modifier
-            .size(72.dp)
+            .size(64.dp)
             .background(backGroundColor, CircleShape),
     ) {
         Icon(
-            modifier = Modifier.size(40.dp),
+            modifier = Modifier.size(32.dp),
             imageVector = icon,
             contentDescription = "",
             tint = Color.White

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -220,7 +220,8 @@ fun MainScreen(mainScreenViewModel: MainScreenViewModel, navController: NavHostC
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 /**レコーディング操作ボタン（New）**/
                 RecordingButton(
@@ -281,21 +282,22 @@ fun MainScreen(mainScreenViewModel: MainScreenViewModel, navController: NavHostC
                         }
                     }
                 )
-            }
-            /**要約ボタン**/
-            OperationButton(
-                modifier = maxModifierButton,
-                buttonName = stringResource(R.string.recording_summarize),
-                enabled = convertTextAreaState.currentState,
-                clickAction = {
-                    /**要約表示画面に遷移**/
-//                mainScreenViewModel.summary(mainScreenViewModel.audioText.value,/*navController*/)
-                    navController.navigate("${Nav.SummaryScreen.name}/summarize"){
-                        popUpTo(Nav.MainScreen.name) { inclusive = true }
-                        launchSingleTop = true
+
+                /**要約ボタン**/
+                OperationButton(
+                    modifier = Modifier.height(88.dp),
+                    buttonName = stringResource(R.string.recording_summarize),
+                    enabled = convertTextAreaState.currentState,
+                    clickAction = {
+                        /**要約表示画面に遷移**/
+        //                mainScreenViewModel.summary(mainScreenViewModel.audioText.value,/*navController*/)
+                        navController.navigate("${Nav.SummaryScreen.name}/summarize") {
+                            popUpTo(Nav.MainScreen.name) { inclusive = true }
+                            launchSingleTop = true
+                        }
                     }
-                }
-            )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
+++ b/app/src/main/java/biz/moapp/transcription_app/ui/main/MainScreen.kt
@@ -223,6 +223,29 @@ fun MainScreen(mainScreenViewModel: MainScreenViewModel, navController: NavHostC
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                Spacer(modifier = Modifier.width(40.dp))
+                /**録音完了(New)**/
+                RecordingButton(isEnable = isRecordingComplete,
+                    buttonName = stringResource(R.string.recording_complete),
+                    icon = Icons.Filled.Stop,
+                    onToggle = {
+                        if(isRecordingComplete) {
+                            /**レコーディング停止**/
+                            mainScreenViewModel.recordingStop(recorder)
+                            /**録音した内容を文字起こし**/
+                            mainScreenViewModel.openAiAudioApi(filePath)
+                            /**文字起こしエリア表示**/
+                            convertTextAreaState.targetState = true
+                            /**ボタンのフラグを元に戻す**/
+                            isRecording = false
+                            isRecordingPause = true
+                            isRecordingComplete = false
+                        }
+                    }
+                )
+
+                Spacer(modifier = Modifier.width(40.dp))
+
                 /**レコーディング操作ボタン（New）**/
                 RecordingButton(
                     isEnable = isRecording,
@@ -260,29 +283,7 @@ fun MainScreen(mainScreenViewModel: MainScreenViewModel, navController: NavHostC
                         }
                     },
                 )
-
                 Spacer(modifier = Modifier.width(16.dp))
-
-                /**録音完了(New)**/
-                RecordingButton(isEnable = isRecordingComplete,
-                    buttonName = stringResource(R.string.recording_complete),
-                    icon = Icons.Filled.Stop,
-                    onToggle = {
-                        if(isRecordingComplete) {
-                            /**レコーディング停止**/
-                            mainScreenViewModel.recordingStop(recorder)
-                            /**録音した内容を文字起こし**/
-                            mainScreenViewModel.openAiAudioApi(filePath)
-                            /**文字起こしエリア表示**/
-                            convertTextAreaState.targetState = true
-                            /**ボタンのフラグを元に戻す**/
-                            isRecording = false
-                            isRecordingPause = true
-                            isRecordingComplete = false
-                        }
-                    }
-                )
-
                 /**要約ボタン**/
                 OperationButton(
                     modifier = Modifier.height(88.dp),


### PR DESCRIPTION
以下内容の修正
- 「AIまとめ」ボタンの配置位置を録音ボタンと横並びにする
- 「AIまとめ」ボタンの形をレコーディングボタンと似ているような形に丸める
- 録音ボタンと録音完了ボタンを逆に配置(録音ボタンを真ん中にして完了ボタンんを左端)
